### PR TITLE
CI: optimized ARC runners — 2 ARC + 2 GitHub shards

### DIFF
--- a/.github/helper/hydrate.sh
+++ b/.github/helper/hydrate.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Hydrate a test shard from the setup job's artifact.
+#
+# The bench (apps, venv, node_modules, sites) is already on disk at ~/frappe-bench — the
+# workflow untar'd it from the artifact the setup job built. So there is NO bench init, no
+# asset build, and no reinstall here: just bring the DB up and restore the dump the setup job
+# baked into the bench, then start bench so tests can run. Mirrors the DB + bench-start tail of
+# install.sh. The whole point is that the expensive work happened ONCE in the setup job.
+#
+set -e
+
+ci_user="${ERPNEXT_CI_USER:-frappe}"
+db_host="${DB_HOST:-127.0.0.1}"
+dump="${CI_BASELINE_BACKUP:-/home/$ci_user/frappe-bench/test_site-db.sql.gz}"
+
+# Re-exec as the ci user (uid 1001) so bench/cache ownership matches the artifact, same as
+# install.sh. The workflow untar'd as root with -p, so the files are already owned by ci.
+if [ "$(id -u)" = "0" ] && [ "${SKIP_SYSTEM_SETUP:-0}" = "1" ] && [ "$ci_user" != "root" ]; then
+    exec su -m "$ci_user" -s /bin/bash -c \
+        "ERPNEXT_CI_USER='$ci_user' DB_HOST='$db_host' CI_BASELINE_BACKUP='$dump' bash '$0'"
+fi
+
+cd ~/frappe-bench
+
+# MariaDB readiness + throwaway-DB tuning. The shard's mysql service is empty; `bench restore`
+# (below) creates the DB and loads the dump, so no manual CREATE DATABASE is needed.
+for _ in {1..60}; do
+    mariadb-admin ping --host "$db_host" --port 3306 -u root -proot --silent && break
+    sleep 1
+done
+mariadb --host "$db_host" --port 3306 -u root -proot \
+    -e "SET GLOBAL character_set_server='utf8mb4'; SET GLOBAL collation_server='utf8mb4_unicode_ci'; SET GLOBAL innodb_flush_log_at_trx_commit=0; SET GLOBAL sync_binlog=0;"
+
+# Restore the site DB from the artifact dump — this is what replaces the per-shard reinstall.
+bench --site test_site --force restore --db-root-username root --db-root-password root "$dump"
+
+# Bring up bench (redis + web; PDF tests need the web server) and wait for redis, as install.sh.
+bench start >> ~/frappe-bench/bench_start.log 2>&1 &
+
+cfg=~/frappe-bench/sites/common_site_config.json
+if [ -f "$cfg" ]; then
+    ports=$(python - "$cfg" <<'PY'
+import json, re, sys
+try:
+    cfg = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(0)
+for key in ("redis_cache", "redis_queue"):
+    m = re.search(r":(\d+)", str(cfg.get(key, "")))
+    if m:
+        print(m.group(1))
+PY
+)
+    for port in $ports; do
+        for _ in $(seq 1 120); do
+            if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then exec 3>&- 3<&-; break; fi
+            sleep 1
+        done
+    done
+fi
+
+echo "Hydrated: bench untar'd, DB restored, bench started — ready for tests."

--- a/.github/helper/hydrate.sh
+++ b/.github/helper/hydrate.sh
@@ -33,7 +33,13 @@ mariadb --host "$db_host" --port 3306 -u root -proot \
     -e "SET GLOBAL character_set_server='utf8mb4'; SET GLOBAL collation_server='utf8mb4_unicode_ci'; SET GLOBAL innodb_flush_log_at_trx_commit=0; SET GLOBAL sync_binlog=0;"
 
 # Restore the site DB from the artifact dump — this is what replaces the per-shard reinstall.
-bench --site test_site --force restore --db-root-username root --db-root-password root "$dump"
+# We load it with the mariadb client directly instead of `bench restore`, because bench restore
+# shells out to the `file` utility (not installed in the runner image) to sniff compression.
+mariadb --host "$db_host" --port 3306 -u root -proot -e \
+    "DROP DATABASE IF EXISTS test_frappe; CREATE DATABASE test_frappe; \
+     CREATE USER IF NOT EXISTS 'test_frappe'@'%' IDENTIFIED BY 'test_frappe'; \
+     GRANT ALL PRIVILEGES ON \`test_frappe\`.* TO 'test_frappe'@'%'; FLUSH PRIVILEGES;"
+gunzip -c "$dump" | mariadb --host "$db_host" --port 3306 -u root -proot test_frappe
 
 # Bring up bench (redis + web; PDF tests need the web server) and wait for redis, as install.sh.
 bench start >> ~/frappe-bench/bench_start.log 2>&1 &

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -270,11 +270,5 @@ run_ci_step "Get erpnext app" bench get-app erpnext "${GITHUB_WORKSPACE}"
 
 if [ "$TYPE" == "server" ]; then run_ci_step "Setup dev requirements" bench setup requirements --dev; fi
 
-# Tests need only redis (enqueued jobs run inline in test mode). Strip the web server and
-# workers so `bench start` brings redis up instantly, instead of letting gunicorn's heavy
-# erpnext import starve redis startup under CPU load — that starvation caused flaky test
-# failures once several jobs ran concurrently on one node.
-sed -i -E 's/^(web|worker[a-z_]*):/# \1:/' ~/frappe-bench/Procfile
-
 bench start >> ~/frappe-bench/bench_start.log 2>&1 &
 run_ci_step "Reinstall test site" bench --site test_site reinstall --yes

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -271,4 +271,35 @@ run_ci_step "Get erpnext app" bench get-app erpnext "${GITHUB_WORKSPACE}"
 if [ "$TYPE" == "server" ]; then run_ci_step "Setup dev requirements" bench setup requirements --dev; fi
 
 bench start >> ~/frappe-bench/bench_start.log 2>&1 &
+
+# Under heavy concurrency, gunicorn's startup can delay redis coming up. reinstall and the
+# tests need redis, so wait for it (best-effort, bounded) instead of racing — contention
+# then slows the job rather than failing it.
+wait_for_redis() {
+    local cfg=~/frappe-bench/sites/common_site_config.json
+    [ -f "$cfg" ] || return 0
+    local ports port
+    ports=$(python - "$cfg" <<'PY'
+import json, re, sys
+try:
+    cfg = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(0)
+for key in ("redis_cache", "redis_queue"):
+    match = re.search(r":(\d+)", str(cfg.get(key, "")))
+    if match:
+        print(match.group(1))
+PY
+)
+    for port in $ports; do
+        for _ in $(seq 1 120); do
+            if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+                exec 3>&- 3<&-
+                break
+            fi
+            sleep 1
+        done
+    done
+}
+wait_for_redis
 run_ci_step "Reinstall test site" bench --site test_site reinstall --yes

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -270,5 +270,11 @@ run_ci_step "Get erpnext app" bench get-app erpnext "${GITHUB_WORKSPACE}"
 
 if [ "$TYPE" == "server" ]; then run_ci_step "Setup dev requirements" bench setup requirements --dev; fi
 
+# Tests need only redis (enqueued jobs run inline in test mode). Strip the web server and
+# workers so `bench start` brings redis up instantly, instead of letting gunicorn's heavy
+# erpnext import starve redis startup under CPU load — that starvation caused flaky test
+# failures once several jobs ran concurrently on one node.
+sed -i -E 's/^(web|worker[a-z_]*):/# \1:/' ~/frappe-bench/Procfile
+
 bench start >> ~/frappe-bench/bench_start.log 2>&1 &
 run_ci_step "Reinstall test site" bench --site test_site reinstall --yes

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -339,4 +339,38 @@ PY
     done
 }
 wait_for_redis
-run_ci_step "Reinstall test site" bench --site test_site reinstall --yes
+
+# Site setup. `bench reinstall` rebuilds the entire schema in Python (~1000 DocTypes) — the
+# CI bottleneck that DB tuning / tmpfs / faster cores couldn't move. Instead, restore a
+# pre-baked baseline (the DB engine loads it, no Python schema-build) and `migrate` to sync
+# only the drift since the baseline was built. The baseline is produced by
+# .github/helper/generate-ci-baseline.sh (run nightly / at image build) from a clean
+# reinstall on develop. Gated by CI_RESTORE_FROM_BACKUP so it A/Bs against plain reinstall;
+# falls back to reinstall if the baseline is missing or the restore fails.
+CI_BASELINE_BACKUP="${CI_BASELINE_BACKUP:-/opt/ci-baseline/test_site-database.sql.gz}"
+if [ "${CI_RESTORE_FROM_BACKUP:-0}" = "1" ] && [ -f "$CI_BASELINE_BACKUP" ]; then
+    if [ "$DB" == "mariadb" ]; then
+        db_root_args=(--db-root-username root --db-root-password root)
+    else
+        db_root_args=(--db-root-username postgres --db-root-password travis)
+    fi
+    if run_ci_step "Restore baseline test site" bench --site test_site --force restore "${db_root_args[@]}" "$CI_BASELINE_BACKUP"; then
+        run_ci_step "Migrate test site" bench --site test_site migrate
+    else
+        run_ci_step "Reinstall test site (baseline restore failed)" bench --site test_site reinstall --yes
+    fi
+else
+    run_ci_step "Reinstall test site" bench --site test_site reinstall --yes
+fi
+
+# Refresh the baseline backup from this freshly set-up site. Run a normal job (reinstall path)
+# with CI_GENERATE_BASELINE=1 and the baseline dir mounted read-write; install.sh captures the
+# DB dump to CI_BASELINE_BACKUP so future runs can restore it. Nightly is enough — bench migrate
+# absorbs intraday develop drift. To bake into the image instead, copy the produced .sql.gz in.
+if [ "${CI_GENERATE_BASELINE:-0}" = "1" ]; then
+    run_ci_step "Backup baseline test site" bench --site test_site backup
+    latest_backup=$(ls -t ~/frappe-bench/sites/test_site/private/backups/*-database.sql.gz | head -1)
+    mkdir -p "$(dirname "$CI_BASELINE_BACKUP")"
+    cp "$latest_backup" "$CI_BASELINE_BACKUP"
+    echo "Baseline written to $CI_BASELINE_BACKUP ($(du -h "$latest_backup" | cut -f1))"
+fi

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -173,6 +173,14 @@ restore_warm_bench() {
         return 1
     fi
 
+    # Pick up any frappe dependency changes since the base was built (cached → fast if none),
+    # so a develop commit that bumped requirements doesn't leave a stale venv.
+    if ! ~/frappe-bench/env/bin/python -m pip install -q -e ~/frappe-bench/apps/frappe; then
+        echo "frappe dependency refresh failed; falling back to full init"
+        rm -rf ~/frappe-bench
+        return 1
+    fi
+
     ( cd ~/frappe-bench && CI=Yes bench build --app frappe ) || { rm -rf ~/frappe-bench; return 1; }
     return 0
 }

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -165,10 +165,13 @@ restore_warm_bench() {
     # no reinstall. Any failure returns non-zero so the caller falls back to a full bench init.
     if ! (
         cd ~/frappe-bench/apps/frappe || exit 1
-        git fetch --depth 200 origin "${frappecommitish}" || exit 1
-        git checkout --force "$frappe_sha" 2>/dev/null || exit 1
+        # Phase 1 already fetched ~/frappe to the exact live develop SHA. Fetch that commit
+        # straight from it (bench init names the remote 'upstream', not 'origin', and points
+        # it at this local clone — so a plain `git fetch origin` does not work).
+        git fetch --no-tags "$HOME/frappe" HEAD || exit 1
+        git checkout --force FETCH_HEAD || exit 1
     ); then
-        echo "Fast-forward to ${frappe_sha} failed (base too stale?); falling back to full init"
+        echo "Fast-forward to ${frappe_sha} failed; falling back to full init"
         rm -rf ~/frappe-bench
         return 1
     fi

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -266,10 +266,10 @@ if [ "$DB" == "mariadb" ];then
     mariadb --host "$db_host" --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
     mariadb --host "$db_host" --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
 
-    # Throwaway-DB durability/perf tuning at runtime. doublewrite=0 skips writing every page
-    # twice (crash safety we don't need here) — roughly halves page-write I/O during reinstall.
+    # Throwaway-DB durability tuning at runtime. (innodb_doublewrite is read-only on MariaDB
+    # 10.6, so it can't be disabled here — would need a server startup flag.)
     mariadb --host "$db_host" --port 3306 -u root -proot \
-        -e "SET GLOBAL innodb_flush_log_at_trx_commit=0; SET GLOBAL sync_binlog=0; SET GLOBAL innodb_doublewrite=0;"
+        -e "SET GLOBAL innodb_flush_log_at_trx_commit=0; SET GLOBAL sync_binlog=0;"
 
     # Opt-in DDL speedup: a shared tablespace avoids a create+fsync per DocType table during
     # reinstall — a big win under disk contention. But ROW_FORMAT=DYNAMIC must be accepted in

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -294,7 +294,13 @@ fi
 cd ~/frappe-bench || exit
 
 run_ci_step "Get payments app" bench get-app payments --branch develop
-run_ci_step "Get erpnext app" bench get-app erpnext "${GITHUB_WORKSPACE}"
+
+# Opt-in: skip building erpnext's frontend assets. Server tests don't need them, but PDF
+# tests (print formats) do — they pass only if the PDF renderer ignores missing assets.
+# Enable with CI_SKIP_ERPNEXT_ASSETS=1 to test; if PDF tests fail, unset it.
+erpnext_get_app_args=()
+if [ "${CI_SKIP_ERPNEXT_ASSETS:-0}" = "1" ]; then erpnext_get_app_args=(--skip-assets); fi
+run_ci_step "Get erpnext app" bench get-app erpnext "${GITHUB_WORKSPACE}" "${erpnext_get_app_args[@]}"
 
 if [ "$TYPE" == "server" ]; then run_ci_step "Setup dev requirements" bench setup requirements --dev; fi
 

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -133,10 +133,12 @@ get_bench_cache_archive() {
 
     mkdir -p "$bench_cache_dir"
 
+    # Keyed on tool versions only (NOT the frappe SHA): any recent base bench works, because
+    # restore_warm_bench fast-forwards it to the exact live develop SHA. This is what lets a
+    # constantly-moving develop still hit the cache.
     local cache_key
     cache_key=$(
         {
-            echo "frappe:${frappe_sha}"
             uname -m
             python --version
             node --version
@@ -144,25 +146,35 @@ get_bench_cache_archive() {
         } | sha256sum | awk '{print $1}'
     )
 
-    echo "${bench_cache_dir}/frappe-bench-${cache_key}.tar.zst"
+    echo "${bench_cache_dir}/frappe-bench-base-${cache_key}.tar.zst"
 }
 
 restore_warm_bench() {
     bench_cache_archive=$(get_bench_cache_archive)
-    if [ -n "$bench_cache_archive" ] && [ -f "$bench_cache_archive" ]; then
-        echo "Restoring warm bench from ${bench_cache_archive}"
-        tar --use-compress-program=unzstd -xf "$bench_cache_archive" -C ~
-        mkdir -p ~/frappe-bench/sites ~/frappe-bench/logs
-        if [ ! -f ~/frappe-bench/sites/apps.txt ]; then
-            printf "frappe\n" > ~/frappe-bench/sites/apps.txt
-        fi
-        if [ ! -f ~/frappe-bench/sites/common_site_config.json ]; then
-            printf "{}\n" > ~/frappe-bench/sites/common_site_config.json
-        fi
-        return 0
+    [ -n "$bench_cache_archive" ] && [ -f "$bench_cache_archive" ] || return 1
+
+    echo "Restoring base bench from ${bench_cache_archive}"
+    tar --use-compress-program=unzstd -xf "$bench_cache_archive" -C ~ || return 1
+    [ -d ~/frappe-bench/apps/frappe/.git ] || return 1
+    mkdir -p ~/frappe-bench/sites ~/frappe-bench/logs
+    [ -f ~/frappe-bench/sites/apps.txt ] || printf "frappe\n" > ~/frappe-bench/sites/apps.txt
+    [ -f ~/frappe-bench/sites/common_site_config.json ] || printf "{}\n" > ~/frappe-bench/sites/common_site_config.json
+
+    # Fast-forward the restored frappe to the EXACT live develop SHA fetched in phase 1, then
+    # rebuild only what changed. The editable install means the venv tracks the new code with
+    # no reinstall. Any failure returns non-zero so the caller falls back to a full bench init.
+    if ! (
+        cd ~/frappe-bench/apps/frappe || exit 1
+        git fetch --depth 200 origin "${frappecommitish}" || exit 1
+        git checkout --force "$frappe_sha" 2>/dev/null || exit 1
+    ); then
+        echo "Fast-forward to ${frappe_sha} failed (base too stale?); falling back to full init"
+        rm -rf ~/frappe-bench
+        return 1
     fi
 
-    return 1
+    ( cd ~/frappe-bench && CI=Yes bench build --app frappe ) || { rm -rf ~/frappe-bench; return 1; }
+    return 0
 }
 
 save_warm_bench() {
@@ -246,10 +258,18 @@ if [ "$DB" == "mariadb" ];then
     mariadb --host "$db_host" --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
     mariadb --host "$db_host" --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
 
-    # Belt-and-suspenders: also set performance variables at runtime in case
-    # MARIADB_EXTRA_FLAGS was not honoured by the container image.
+    # Throwaway-DB durability/perf tuning at runtime. doublewrite=0 skips writing every page
+    # twice (crash safety we don't need here) — roughly halves page-write I/O during reinstall.
     mariadb --host "$db_host" --port 3306 -u root -proot \
-        -e "SET GLOBAL innodb_flush_log_at_trx_commit=0; SET GLOBAL sync_binlog=0;"
+        -e "SET GLOBAL innodb_flush_log_at_trx_commit=0; SET GLOBAL sync_binlog=0; SET GLOBAL innodb_doublewrite=0;"
+
+    # Opt-in DDL speedup: a shared tablespace avoids a create+fsync per DocType table during
+    # reinstall — a big win under disk contention. But ROW_FORMAT=DYNAMIC must be accepted in
+    # the system tablespace on this MariaDB. Enable with CI_INNODB_SHARED_TABLESPACE=1; if
+    # reinstall then errors on table creation, unset it (off by default — zero risk).
+    if [ "${CI_INNODB_SHARED_TABLESPACE:-0}" = "1" ]; then
+        mariadb --host "$db_host" --port 3306 -u root -proot -e "SET GLOBAL innodb_file_per_table=0;"
+    fi
 
     mariadb --host "$db_host" --port 3306 -u root -proot -e "CREATE USER 'test_frappe'@'${db_user_host}' IDENTIFIED BY 'test_frappe'"
     mariadb --host "$db_host" --port 3306 -u root -proot -e "CREATE DATABASE test_frappe"

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -65,6 +65,19 @@ jobs:
       - name: Add to Hosts
         run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
 
+      # The v14 baseline backup is a fixed published file — cache it instead of re-downloading
+      # ~100MB from frappe.io every run.
+      - name: Cache erpnext v14 backup
+        id: cache-v14
+        uses: actions/cache@v4
+        with:
+          path: ~/erpnext-v14.sql.gz
+          key: erpnext-v14-sql-gz
+
+      - name: Download erpnext v14 backup
+        if: steps.cache-v14.outputs.cache-hit != 'true'
+        run: wget -O ~/erpnext-v14.sql.gz https://frappe.io/files/erpnext-v14.sql.gz
+
       - name: Cache pip
         uses: actions/cache@v4
         with:
@@ -113,8 +126,7 @@ jobs:
           jq 'del(.install_apps)' ~/frappe-bench/sites/test_site/site_config.json > tmp.json
           mv tmp.json ~/frappe-bench/sites/test_site/site_config.json
 
-          wget https://frappe.io/files/erpnext-v14.sql.gz
-          bench --site test_site --force restore ~/frappe-bench/erpnext-v14.sql.gz
+          bench --site test_site --force restore ~/erpnext-v14.sql.gz
 
           git -C "apps/frappe" remote set-url upstream https://github.com/frappe/frappe.git
           git -C "apps/erpnext" remote set-url upstream https://github.com/frappe/erpnext.git

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -113,9 +113,10 @@ jobs:
           DB_HOST: 127.0.0.1
           DB_USER_HOST: '%'
           WKHTMLTOX_DEB: /tmp/wkhtmltox.deb
-          # No BENCH_CACHE_DIR: every run does a full `bench init` against live develop
-          # (like GitHub-hosted). The SHA-keyed warm bench rarely hit (develop moves
-          # hourly) and its fast path raced Redis on reinstall. Baked caches + tmpfs stay.
+          # Warm bench: restore a recent base bench and fast-forward it to the exact live
+          # develop SHA (see install.sh) — skips bench init + frappe asset build. Requires a
+          # persistent, ci-writable cache dir on the node (hook-extension hostPath volume).
+          BENCH_CACHE_DIR: /opt/erpnext-ci-cache/bench
           SKIP_SYSTEM_SETUP: "1"
           SKIP_WKHTMLTOX_SETUP: "1"
 

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -37,10 +37,28 @@ concurrency:
   group: server-mariadb-develop-${{ github.event_name }}-${{ github.event.number || github.event_name == 'workflow_dispatch' && github.run_id || '' }}
   cancel-in-progress: true
 
+# Shared across both jobs. Both run in the SAME arc4 container so the bench lives at the
+# identical path (/home/ci/frappe-bench) on the GitHub-hosted setup runner and the self-hosted
+# test runners — that's what makes the packaged Python venv portable between them.
+env:
+  TZ: 'Asia/Kolkata'
+  DEBIAN_FRONTEND: noninteractive
+  NODE_ENV: "production"
+  WITH_COVERAGE: ${{ github.event_name != 'pull_request' }}
+  ERPNEXT_CI_USER: ci
+  PIP_CACHE_DIR: /home/ci/.cache/pip
+  npm_config_cache: /home/ci/.cache/npm
+  YARN_CACHE_FOLDER: /home/ci/.cache/yarn
+  UV_CACHE_DIR: /home/ci/.cache/uv
+
 jobs:
-  test:
-    runs-on: erpnext-arc
-    timeout-minutes: 60
+  # Build the bench (clone + pip + yarn + assets) and reinstall test_site ONCE, on a free
+  # GitHub-hosted runner, then publish the whole bench (with a DB dump baked in) as an artifact.
+  # The expensive, non-parallelisable work happens here exactly once instead of on every shard.
+  setup:
+    name: Build & reinstall (setup)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
     container:
       image: ghcr.io/mihir-kandoi/erpnext-ci-mariadb:py3.14-node24-arc4
       credentials:
@@ -49,46 +67,13 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      TZ: 'Asia/Kolkata'
-      DEBIAN_FRONTEND: noninteractive
-      NODE_ENV: "production"
-      WITH_COVERAGE: ${{ github.event_name != 'pull_request' }}
-      # Run as the image's build user (uid 1001) so the baked caches under
-      # /home/ci/.cache are writable; a different user can't write those files.
-      ERPNEXT_CI_USER: ci
-      # Dependency caches live under /home/ci/.cache so a persistent volume (or a
-      # cache baked into the image) can warm yarn/uv/pip across runs.
-      PIP_CACHE_DIR: /home/ci/.cache/pip
-      npm_config_cache: /home/ci/.cache/npm
-      YARN_CACHE_FOLDER: /home/ci/.cache/yarn
-      UV_CACHE_DIR: /home/ci/.cache/uv
-
-    strategy:
-      fail-fast: false
-
-      matrix:
-        container: [1, 2, 3, 4]
-
-    name: Python Unit Tests (ARC)
-
     services:
       mysql:
-        # Stock mariadb:10.6. A custom my.cnf (nosync/doublewrite=0) was tested and gave NO
-        # reinstall speedup — on NVMe the cost is overlayfs small-file + CPU schema-sync, not
-        # fsync. Not worth a custom image.
         image: mariadb:10.6
         env:
           TZ: 'Asia/Kolkata'
           MARIADB_ROOT_PASSWORD: 'root'
-          # Disable durability guarantees that are unnecessary in a throwaway CI container.
-          # innodb_flush_log_at_trx_commit=0 avoids an fsync on every commit (biggest win).
-          # sync_binlog=0 skips binary-log syncs; innodb_doublewrite=0 skips the doublewrite buffer.
           MARIADB_EXTRA_FLAGS: --innodb-flush-log-at-trx-commit=0 --sync-binlog=0 --innodb-doublewrite=0
-        # DB datadir on disk (no tmpfs) so ~20 jobs fit in 64GB RAM (tmpfs is ~1.5GB/job and
-        # caps concurrency near 8). Slower per job — the trade for 20-wide on one box. The
-        # web server stays up (PDF tests need it) and install.sh waits for redis before
-        # reinstall, so contention slows jobs rather than failing them.
         options: --health-cmd="mariadb-admin ping -h 127.0.0.1 -uroot -proot" --health-interval=5s --health-timeout=2s --health-retries=10
 
     steps:
@@ -106,10 +91,8 @@ jobs:
       - name: Add to Hosts
         run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
 
-      # No actions/cache here: the uv/pip/yarn caches under /home/ci/.cache are kept warm by a
-      # persistent, ci-owned hostPath volume on the node (mounted via the hook-extension). On
-      # a self-hosted box a local NVMe cache restores instantly, avoiding the ~60s round-trip
-      # to GitHub's cache backend that actions/cache pays for the large yarn cache.
+      # Full install: bench init + get-app + build + reinstall, and (CI_GENERATE_BASELINE) dump
+      # the freshly-reinstalled DB into the bench dir so it travels inside the artifact.
       - name: Install
         run: bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
         env:
@@ -120,16 +103,78 @@ jobs:
           DB_HOST: 127.0.0.1
           DB_USER_HOST: '%'
           WKHTMLTOX_DEB: /tmp/wkhtmltox.deb
-          # NOTE: innodb_file_per_table=0 (CI_INNODB_SHARED_TABLESPACE) is NOT usable — frappe's
-          # ROW_FORMAT=DYNAMIC tables are rejected in the shared tablespace (errno 140), even on
-          # 10.11. The fsync-free win comes from the tuned mariadb image's my.cnf instead.
           SKIP_SYSTEM_SETUP: "1"
           SKIP_WKHTMLTOX_SETUP: "1"
-          # CI site-setup A/B (restore a baked baseline vs full reinstall).
-          # Phase 1 (now): generate the baseline. Phase 2: flip to
-          # CI_GENERATE_BASELINE "0" + CI_RESTORE_FROM_BACKUP "1" to measure restore+migrate.
           CI_GENERATE_BASELINE: "1"
-          CI_RESTORE_FROM_BACKUP: "0"
+          CI_BASELINE_BACKUP: /home/ci/frappe-bench/test_site-db.sql.gz
+
+      # Package the whole bench (apps, venv, node_modules, sites, the DB dump, and hydrate.sh)
+      # into one artifact for the test shards to consume.
+      - name: Package bench for test shards
+        run: |
+          cp "${GITHUB_WORKSPACE}/.github/helper/hydrate.sh" /home/ci/frappe-bench/hydrate.sh
+          tar czpf "${GITHUB_WORKSPACE}/bench.tar.gz" -C /home/ci frappe-bench
+          ls -lh "${GITHUB_WORKSPACE}/bench.tar.gz"
+
+      - name: Upload bench artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-and-db
+          path: bench.tar.gz
+          retention-days: 1
+          compression-level: 0
+
+  # Fan-out: each shard downloads the bench, untars it, restores the DB dump, and runs its
+  # slice of the suite. No clone, no build, no reinstall on the self-hosted boxes.
+  test:
+    name: Python Unit Tests (ARC)
+    needs: setup
+    runs-on: erpnext-arc
+    timeout-minutes: 60
+    container:
+      image: ghcr.io/mihir-kandoi/erpnext-ci-mariadb:py3.14-node24-arc4
+      credentials:
+        username: ${{ secrets.GHCR_USERNAME || github.actor }}
+        password: ${{ secrets.GHCR_TOKEN || github.token }}
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        container: [1, 2, 3, 4]
+
+    services:
+      mysql:
+        image: mariadb:10.6
+        env:
+          TZ: 'Asia/Kolkata'
+          MARIADB_ROOT_PASSWORD: 'root'
+          MARIADB_EXTRA_FLAGS: --innodb-flush-log-at-trx-commit=0 --sync-binlog=0 --innodb-doublewrite=0
+        options: --health-cmd="mariadb-admin ping -h 127.0.0.1 -uroot -proot" --health-interval=5s --health-timeout=2s --health-retries=10
+
+    steps:
+      - name: Download bench artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: bench-and-db
+
+      - name: Add to Hosts
+        run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
+
+      # -p preserves the ci (uid 1001) ownership baked into the tar, so bench runs as ci cleanly.
+      - name: Untar bench
+        run: |
+          tar xzpf "${GITHUB_WORKSPACE}/bench.tar.gz" -C /home/ci
+          ls -ld /home/ci/frappe-bench
+
+      - name: Hydrate (DB up + restore + bench start)
+        run: bash /home/ci/frappe-bench/hydrate.sh
+        env:
+          DB_HOST: 127.0.0.1
+          SKIP_SYSTEM_SETUP: "1"
+          CI_BASELINE_BACKUP: /home/ci/frappe-bench/test_site-db.sql.gz
 
       - name: Run Tests
         run: |
@@ -145,7 +190,6 @@ jobs:
         env:
           TYPE: server
 
-
       - name: Show bench output
         if: ${{ always() }}
         run: cat ~/frappe-bench/bench_start.log || true
@@ -155,7 +199,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.container }}
-          path: /github/home/frappe-bench/sites/coverage.xml
+          path: /home/ci/frappe-bench/sites/coverage.xml
 
   coverage:
     name: Coverage Wrap Up

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -125,6 +125,11 @@ jobs:
           # 10.11. The fsync-free win comes from the tuned mariadb image's my.cnf instead.
           SKIP_SYSTEM_SETUP: "1"
           SKIP_WKHTMLTOX_SETUP: "1"
+          # CI site-setup A/B (restore a baked baseline vs full reinstall).
+          # Phase 1 (now): generate the baseline. Phase 2: flip to
+          # CI_GENERATE_BASELINE "0" + CI_RESTORE_FROM_BACKUP "1" to measure restore+migrate.
+          CI_GENERATE_BASELINE: "1"
+          CI_RESTORE_FROM_BACKUP: "0"
 
       - name: Run Tests
         run: |

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -82,11 +82,10 @@ jobs:
           # innodb_flush_log_at_trx_commit=0 avoids an fsync on every commit (biggest win).
           # sync_binlog=0 skips binary-log syncs; innodb_doublewrite=0 skips the doublewrite buffer.
           MARIADB_EXTRA_FLAGS: --innodb-flush-log-at-trx-commit=0 --sync-binlog=0 --innodb-doublewrite=0
-        # DB datadir left on disk (no tmpfs). A RAM-backed datadir is ~1.5GB/job, which
-        # caps concurrency on a 64GB node (≈12 jobs before OOM). On disk each job uses
-        # ~2.5GB, letting ~20 jobs share the node. Slower per job, but it fits in RAM.
-        # Re-add `--tmpfs /var/lib/mysql:size=3g` to trade concurrency back for speed.
-        options: --health-cmd="mariadb-admin ping -h 127.0.0.1 -uroot -proot" --health-interval=5s --health-timeout=2s --health-retries=10
+        # DB datadir on tmpfs (RAM): bench reinstall creates one .ibd file per DocType and
+        # tests are query-heavy; RAM makes both fast (beats GitHub's SSD). size=3g caps
+        # per-DB RAM. This is why concurrency is bounded near 8 on a 64GB node.
+        options: --health-cmd="mariadb-admin ping -h 127.0.0.1 -uroot -proot" --health-interval=5s --health-timeout=2s --health-retries=10 --tmpfs /var/lib/mysql:size=3g
 
     steps:
       - name: Clone

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -82,10 +82,11 @@ jobs:
           # innodb_flush_log_at_trx_commit=0 avoids an fsync on every commit (biggest win).
           # sync_binlog=0 skips binary-log syncs; innodb_doublewrite=0 skips the doublewrite buffer.
           MARIADB_EXTRA_FLAGS: --innodb-flush-log-at-trx-commit=0 --sync-binlog=0 --innodb-doublewrite=0
-        # DB datadir on tmpfs (RAM): bench reinstall creates one .ibd file per DocType and
-        # tests are query-heavy; RAM makes both fast (beats GitHub's SSD). size=3g caps
-        # per-DB RAM. This is why concurrency is bounded near 8 on a 64GB node.
-        options: --health-cmd="mariadb-admin ping -h 127.0.0.1 -uroot -proot" --health-interval=5s --health-timeout=2s --health-retries=10 --tmpfs /var/lib/mysql:size=3g
+        # DB datadir on disk (no tmpfs) so ~20 jobs fit in 64GB RAM (tmpfs is ~1.5GB/job and
+        # caps concurrency near 8). Slower per job — the trade for 20-wide on one box. The
+        # web server stays up (PDF tests need it) and install.sh waits for redis before
+        # reinstall, so contention slows jobs rather than failing them.
+        options: --health-cmd="mariadb-admin ping -h 127.0.0.1 -uroot -proot" --health-interval=5s --health-timeout=2s --health-retries=10
 
     steps:
       - name: Clone

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -104,8 +104,8 @@ jobs:
         run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
 
       # Same dependency caching GitHub-hosted uses, adapted: bench uses `uv pip install`, so
-      # cache uv (not just pip). Caches restore as the container's root user; chown them to
-      # the ci user that install.sh runs as.
+      # cache uv (not just pip). The image's /home/ci/.cache is ci-owned and the cache tar
+      # round-trips ownership, so no chown is needed.
       - name: Cache pip
         uses: actions/cache@v4
         with:
@@ -127,8 +127,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: Fix cache ownership for ci user
-        run: chown -R 1001:1001 /home/ci/.cache || true
 
       - name: Install
         run: bash ${GITHUB_WORKSPACE}/.github/helper/install.sh

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -57,7 +57,10 @@ jobs:
   # The expensive, non-parallelisable work happens here exactly once instead of on every shard.
   setup:
     name: Build & reinstall (setup)
-    runs-on: ubuntu-latest
+    # Self-hosted: same arc4 container + /home/ci path + 127.0.0.1 DB as the test shards, so the
+    # packaged bench (and its venv) transplants cleanly. GitHub-hosted forces HOME=/github/home
+    # and routes services by label, which broke venv portability and the DB connection.
+    runs-on: erpnext-arc
     timeout-minutes: 40
     container:
       image: ghcr.io/mihir-kandoi/erpnext-ci-mariadb:py3.14-node24-arc4

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -82,11 +82,11 @@ jobs:
           # innodb_flush_log_at_trx_commit=0 avoids an fsync on every commit (biggest win).
           # sync_binlog=0 skips binary-log syncs; innodb_doublewrite=0 skips the doublewrite buffer.
           MARIADB_EXTRA_FLAGS: --innodb-flush-log-at-trx-commit=0 --sync-binlog=0 --innodb-doublewrite=0
-        # Put the datadir on tmpfs (RAM). bench reinstall creates one .ibd file per
-        # DocType; on the ARC pod's overlayfs each create+fsync is the dominant install
-        # cost (~300s). tmpfs makes those writes hit RAM, matching GitHub-hosted's SSD.
-        # size=3g caps RAM per DB so many concurrent jobs can't exhaust node memory.
-        options: --health-cmd="mariadb-admin ping -h 127.0.0.1 -uroot -proot" --health-interval=5s --health-timeout=2s --health-retries=10 --tmpfs /var/lib/mysql:size=3g
+        # DB datadir left on disk (no tmpfs). A RAM-backed datadir is ~1.5GB/job, which
+        # caps concurrency on a 64GB node (≈12 jobs before OOM). On disk each job uses
+        # ~2.5GB, letting ~20 jobs share the node. Slower per job, but it fits in RAM.
+        # Re-add `--tmpfs /var/lib/mysql:size=3g` to trade concurrency back for speed.
+        options: --health-cmd="mariadb-admin ping -h 127.0.0.1 -uroot -proot" --health-interval=5s --health-timeout=2s --health-retries=10
 
     steps:
       - name: Clone

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -116,7 +116,11 @@ jobs:
       - name: Package bench for test shards
         run: |
           cp "${GITHUB_WORKSPACE}/.github/helper/hydrate.sh" /home/ci/frappe-bench/hydrate.sh
-          tar czpf "${GITHUB_WORKSPACE}/bench.tar.gz" -C /home/ci frappe-bench
+          # Exclude what server tests don't need: the apps' git history and node_modules
+          # (frontend deps; the built assets under sites/assets are already included). This
+          # shrinks the artifact a lot, cutting the per-shard download time.
+          tar czpf "${GITHUB_WORKSPACE}/bench.tar.gz" -C /home/ci \
+            --exclude='.git' --exclude='node_modules' frappe-bench
           ls -lh "${GITHUB_WORKSPACE}/bench.tar.gz"
 
       - name: Upload bench artifact

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -74,13 +74,10 @@ jobs:
 
     services:
       mysql:
-        # CI-tuned MariaDB 10.11: my.cnf bakes nosync flush + innodb_doublewrite=0 (read-only
-        # at runtime on 10.x) for fsync-free DDL on disk. 10.11 also allows ROW_FORMAT=DYNAMIC
-        # in the system tablespace, so CI_INNODB_SHARED_TABLESPACE is safe.
-        image: ghcr.io/mihir-kandoi/mariadb-ci:10.11-fast
-        credentials:
-          username: ${{ secrets.GHCR_USERNAME || github.actor }}
-          password: ${{ secrets.GHCR_TOKEN || github.token }}
+        # Stock mariadb:10.6. A custom my.cnf (nosync/doublewrite=0) was tested and gave NO
+        # reinstall speedup — on NVMe the cost is overlayfs small-file + CPU schema-sync, not
+        # fsync. Not worth a custom image.
+        image: mariadb:10.6
         env:
           TZ: 'Asia/Kolkata'
           MARIADB_ROOT_PASSWORD: 'root'

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -113,7 +113,9 @@ jobs:
           DB_HOST: 127.0.0.1
           DB_USER_HOST: '%'
           WKHTMLTOX_DEB: /tmp/wkhtmltox.deb
-          BENCH_CACHE_DIR: /opt/erpnext-ci-cache/bench
+          # No BENCH_CACHE_DIR: every run does a full `bench init` against live develop
+          # (like GitHub-hosted). The SHA-keyed warm bench rarely hit (develop moves
+          # hourly) and its fast path raced Redis on reinstall. Baked caches + tmpfs stay.
           SKIP_SYSTEM_SETUP: "1"
           SKIP_WKHTMLTOX_SETUP: "1"
 

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -103,6 +103,33 @@ jobs:
       - name: Add to Hosts
         run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
 
+      # Same dependency caching GitHub-hosted uses, adapted: bench uses `uv pip install`, so
+      # cache uv (not just pip). Caches restore as the container's root user; chown them to
+      # the ci user that install.sh runs as.
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: /home/ci/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: /home/ci/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+      - name: Cache yarn
+        uses: actions/cache@v4
+        with:
+          path: /home/ci/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Fix cache ownership for ci user
+        run: chown -R 1001:1001 /home/ci/.cache || true
+
       - name: Install
         run: bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
         env:
@@ -113,10 +140,6 @@ jobs:
           DB_HOST: 127.0.0.1
           DB_USER_HOST: '%'
           WKHTMLTOX_DEB: /tmp/wkhtmltox.deb
-          # Warm bench: restore a recent base bench and fast-forward it to the exact live
-          # develop SHA (see install.sh) — skips bench init + frappe asset build. Requires a
-          # persistent, ci-writable cache dir on the node (hook-extension hostPath volume).
-          BENCH_CACHE_DIR: /opt/erpnext-ci-cache/bench
           SKIP_SYSTEM_SETUP: "1"
           SKIP_WKHTMLTOX_SETUP: "1"
 

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: erpnext-arc
     timeout-minutes: 60
     container:
-      image: ghcr.io/mihir-kandoi/erpnext-ci-mariadb:py3.14-node24-arc3
+      image: ghcr.io/mihir-kandoi/erpnext-ci-mariadb:py3.14-node24-arc4
       credentials:
         username: ${{ secrets.GHCR_USERNAME || github.actor }}
         password: ${{ secrets.GHCR_TOKEN || github.token }}
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        container: [1, 2, 3, 4]
+        container: [1, 2]
 
     name: Python Unit Tests (ARC)
 
@@ -82,7 +82,8 @@ jobs:
         # Put the datadir on tmpfs (RAM). bench reinstall creates one .ibd file per
         # DocType; on the ARC pod's overlayfs each create+fsync is the dominant install
         # cost (~300s). tmpfs makes those writes hit RAM, matching GitHub-hosted's SSD.
-        options: --health-cmd="mariadb-admin ping -h 127.0.0.1 -uroot -proot" --health-interval=5s --health-timeout=2s --health-retries=10 --tmpfs /var/lib/mysql
+        # size=3g caps RAM per DB so many concurrent jobs can't exhaust node memory.
+        options: --health-cmd="mariadb-admin ping -h 127.0.0.1 -uroot -proot" --health-interval=5s --health-timeout=2s --health-retries=10 --tmpfs /var/lib/mysql:size=3g
 
     steps:
       - name: Clone
@@ -120,7 +121,7 @@ jobs:
           coverage_flag=""
           if [ "$WITH_COVERAGE" = "true" ]; then coverage_flag="--with-coverage"; fi
           bench --site test_site run-parallel-tests --lightmode --app erpnext \
-            --total-builds 6 \
+            --total-builds 4 \
             --build-number ${{ matrix.container }} \
             $coverage_flag
           EOF
@@ -151,7 +152,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        container: [5, 6]
+        container: [3, 4]
 
     name: Python Unit Tests (GitHub Hosted)
 
@@ -248,7 +249,7 @@ jobs:
           coverage_flag=""
           if [ "$WITH_COVERAGE" = "true" ]; then coverage_flag="--with-coverage"; fi
           bench --site test_site run-parallel-tests --lightmode --app erpnext \
-            --total-builds 6 \
+            --total-builds 4 \
             --build-number ${{ matrix.container }} \
             $coverage_flag
         env:

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -123,9 +123,9 @@ jobs:
           DB_HOST: 127.0.0.1
           DB_USER_HOST: '%'
           WKHTMLTOX_DEB: /tmp/wkhtmltox.deb
-          # Shared tablespace: skips a create+fsync per DocType .ibd during reinstall (safe on
-          # MariaDB 10.11, which permits ROW_FORMAT=DYNAMIC in the system tablespace).
-          CI_INNODB_SHARED_TABLESPACE: "1"
+          # NOTE: innodb_file_per_table=0 (CI_INNODB_SHARED_TABLESPACE) is NOT usable — frappe's
+          # ROW_FORMAT=DYNAMIC tables are rejected in the shared tablespace (errno 140), even on
+          # 10.11. The fsync-free win comes from the tuned mariadb image's my.cnf instead.
           SKIP_SYSTEM_SETUP: "1"
           SKIP_WKHTMLTOX_SETUP: "1"
 

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -54,6 +54,9 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       NODE_ENV: "production"
       WITH_COVERAGE: ${{ github.event_name != 'pull_request' }}
+      # Run as the image's build user (uid 1001) so the baked caches under
+      # /home/ci/.cache are writable; a different user can't write those files.
+      ERPNEXT_CI_USER: ci
       # Dependency caches live under /home/ci/.cache so a persistent volume (or a
       # cache baked into the image) can warm yarn/uv/pip across runs.
       PIP_CACHE_DIR: /home/ci/.cache/pip

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -103,31 +103,10 @@ jobs:
       - name: Add to Hosts
         run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
 
-      # Same dependency caching GitHub-hosted uses, adapted: bench uses `uv pip install`, so
-      # cache uv (not just pip). The image's /home/ci/.cache is ci-owned and the cache tar
-      # round-trips ownership, so no chown is needed.
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: /home/ci/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Cache uv
-        uses: actions/cache@v4
-        with:
-          path: /home/ci/.cache/uv
-          key: ${{ runner.os }}-uv-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-uv-
-      - name: Cache yarn
-        uses: actions/cache@v4
-        with:
-          path: /home/ci/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
+      # No actions/cache here: the uv/pip/yarn caches under /home/ci/.cache are kept warm by a
+      # persistent, ci-owned hostPath volume on the node (mounted via the hook-extension). On
+      # a self-hosted box a local NVMe cache restores instantly, avoiding the ~60s round-trip
+      # to GitHub's cache backend that actions/cache pays for the large yarn cache.
       - name: Install
         run: bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
         env:

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -74,7 +74,13 @@ jobs:
 
     services:
       mysql:
-        image: mariadb:10.6
+        # CI-tuned MariaDB 10.11: my.cnf bakes nosync flush + innodb_doublewrite=0 (read-only
+        # at runtime on 10.x) for fsync-free DDL on disk. 10.11 also allows ROW_FORMAT=DYNAMIC
+        # in the system tablespace, so CI_INNODB_SHARED_TABLESPACE is safe.
+        image: ghcr.io/mihir-kandoi/mariadb-ci:10.11-fast
+        credentials:
+          username: ${{ secrets.GHCR_USERNAME || github.actor }}
+          password: ${{ secrets.GHCR_TOKEN || github.token }}
         env:
           TZ: 'Asia/Kolkata'
           MARIADB_ROOT_PASSWORD: 'root'
@@ -117,6 +123,9 @@ jobs:
           DB_HOST: 127.0.0.1
           DB_USER_HOST: '%'
           WKHTMLTOX_DEB: /tmp/wkhtmltox.deb
+          # Shared tablespace: skips a create+fsync per DocType .ibd during reinstall (safe on
+          # MariaDB 10.11, which permits ROW_FORMAT=DYNAMIC in the system tablespace).
+          CI_INNODB_SHARED_TABLESPACE: "1"
           SKIP_SYSTEM_SETUP: "1"
           SKIP_WKHTMLTOX_SETUP: "1"
 

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        container: [1, 2]
+        container: [1, 2, 3, 4]
 
     name: Python Unit Tests (ARC)
 
@@ -152,135 +152,9 @@ jobs:
           name: coverage-${{ matrix.container }}
           path: /github/home/frappe-bench/sites/coverage.xml
 
-  test-github-hosted:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    env:
-      TZ: 'Asia/Kolkata'
-      NODE_ENV: "production"
-      WITH_COVERAGE: ${{ github.event_name != 'pull_request' }}
-
-    strategy:
-      fail-fast: false
-
-      matrix:
-        container: [3, 4]
-
-    name: Python Unit Tests (GitHub Hosted)
-
-    services:
-      mysql:
-        image: mariadb:10.6
-        env:
-          TZ: 'Asia/Kolkata'
-          MARIADB_ROOT_PASSWORD: 'root'
-          # Disable durability guarantees that are unnecessary in a throwaway CI container.
-          # innodb_flush_log_at_trx_commit=0 avoids an fsync on every commit (biggest win).
-          # sync_binlog=0 skips binary-log syncs; innodb_doublewrite=0 skips the doublewrite buffer.
-          MARIADB_EXTRA_FLAGS: --innodb-flush-log-at-trx-commit=0 --sync-binlog=0 --innodb-doublewrite=0
-        ports:
-          - 3306:3306
-        options: --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
-
-    steps:
-      - name: Clone
-        uses: actions/checkout@v6
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-
-      - name: Check for valid Python & Merge Conflicts
-        run: |
-          python -m compileall -fq "${GITHUB_WORKSPACE}"
-          if grep -lr --exclude-dir=node_modules "^<<<<<<< " "${GITHUB_WORKSPACE}"
-              then echo "Found merge conflicts"
-              exit 1
-          fi
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          check-latest: true
-
-      - name: Add to Hosts
-        run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
-
-      - name: Cache node modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Cache wkhtmltopdf
-        uses: actions/cache@v4
-        with:
-          path: /tmp/wkhtmltox.deb
-          key: wkhtmltox-0.12.6.1-2-jammy-amd64
-
-      - name: Install
-        run: bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
-        env:
-          DB: mariadb
-          TYPE: server
-          FRAPPE_USER: ${{ github.event.inputs.user }}
-          FRAPPE_BRANCH: ${{ github.event.client_payload.sha || github.event.inputs.branch || 'develop' }}
-
-      - name: Run Tests
-        run: |
-          cd ~/frappe-bench/
-          coverage_flag=""
-          if [ "$WITH_COVERAGE" = "true" ]; then coverage_flag="--with-coverage"; fi
-          bench --site test_site run-parallel-tests --lightmode --app erpnext \
-            --total-builds 4 \
-            --build-number ${{ matrix.container }} \
-            $coverage_flag
-        env:
-          TYPE: server
-
-      - name: Show bench output
-        if: ${{ always() }}
-        run: cat ~/frappe-bench/bench_start.log || true
-
-      - name: Upload coverage data
-        if: ${{ env.WITH_COVERAGE == 'true' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-${{ matrix.container }}
-          path: /home/runner/frappe-bench/sites/coverage.xml
-
   coverage:
     name: Coverage Wrap Up
-    needs: [test, test-github-hosted]
+    needs: [test]
     if: ${{ always() && github.event_name != 'pull_request' && !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Test run for the optimized self-hosted ARC runner setup.

## Changes
- CI matrix → **4 shards**: 2 ARC (`container: [1, 2]`) + 2 GitHub-hosted (`container: [3, 4]`), `--total-builds 4`.
- ARC container image → `py3.14-node24-arc4` (warm bench + baked yarn/uv/pip caches).
- MariaDB datadir on **tmpfs**, capped at `size=3g`.

## Optimizations under test
- **tmpfs DB** (RAM) → fast `bench reinstall` (was ~300s of overlayfs DDL).
- **baked dependency caches** → fast `get-app erpnext` (uncached yarn install was ~34s).
- **self-warming shared bench cache** keyed on the live develop SHA → fast `bench init`, never stale.
- **per-job CPU/memory requests** (ARC hook template) → scheduler queues excess at `maxRunners: 30`, every running job at full speed.

## Note
ARC shards (1, 2) require the `erpnext-arc` scale set to be online — they queue until the runners register. The GitHub-hosted shards (3, 4) run immediately.

## Verify
- Job pods picked up the CPU/mem requests.
- `Install` step duration vs. baseline.
- ARC vs GitHub-hosted head-to-head across the 4 shards.